### PR TITLE
Add onclick callback for Notifications

### DIFF
--- a/nbextensions/notify.js
+++ b/nbextensions/notify.js
@@ -96,6 +96,7 @@ define(["require"], function (require) {
     var elapsed_time = current_time() - start_time;
     if (enabled && !first_start && !busy_kernel && elapsed_time >= min_time) {
       var n = new Notification(IPython.notebook.notebook_name, {body: "Kernel is now idle\n(ran for " + Math.round(elapsed_time) + " secs)"});
+      n.onclick = function(event){ window.focus(); }
     }
     if (first_start) {
       first_start = false;


### PR DESCRIPTION
When the notification is clicked, the callback "raises" the browser window and (changes to) the tab of the notebook.

Tested to work on:
Firefox 37.0.1
Chrome 41.0.2272.101 m
